### PR TITLE
fix: corriger warning deprecated et de sécurité

### DIFF
--- a/genesis-intellij/src/main/java/org/labs/genesis/actions/GenesisWizardDialog.java
+++ b/genesis-intellij/src/main/java/org/labs/genesis/actions/GenesisWizardDialog.java
@@ -74,7 +74,7 @@ public class GenesisWizardDialog extends AbstractWizard<ModuleWizardStep> {
             if (!currentStep.validate()) return;
             currentStep.updateDataModel();
         } catch (ConfigurationException e) {
-            Messages.showErrorDialog(getContentPane(), e.getMessage(), "Validation Error");
+            Messages.showErrorDialog(getContentPane(), e.getLocalizedMessage(), "Validation Error");
             return;
         }
         super.doNextAction();
@@ -87,14 +87,9 @@ public class GenesisWizardDialog extends AbstractWizard<ModuleWizardStep> {
             if (!currentStep.validate()) return;
             currentStep.updateDataModel();
         } catch (ConfigurationException e) {
-            Messages.showErrorDialog(getContentPane(), e.getMessage(), "Validation Error");
+            Messages.showErrorDialog(getContentPane(), e.getLocalizedMessage(), "Validation Error");
             return;
         }
         super.doOKAction();
-    }
-
-    @Override
-    protected @Nullable String getHelpID() {
-        return null;
     }
 }

--- a/genesis-intellij/src/main/java/org/labs/genesis/forms/FrontendConfigurationForm.java
+++ b/genesis-intellij/src/main/java/org/labs/genesis/forms/FrontendConfigurationForm.java
@@ -126,7 +126,7 @@ public class FrontendConfigurationForm {
             }
         });
 
-        FileChooserDescriptor faviconChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()
+        FileChooserDescriptor faviconChooserDescriptor = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
                 .withTitle("Select favicon file")
                 .withDescription("Choose a .ico file to load into the editor")
                 .withFileFilter(file -> {
@@ -140,7 +140,7 @@ public class FrontendConfigurationForm {
                     );
                 });
 
-        FileChooserDescriptor logoChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()
+        FileChooserDescriptor logoChooserDescriptor = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
                 .withTitle("Select logo file")
                 .withDescription("Choose image or icon file to load into the editor")
                 .withFileFilter(file -> {

--- a/genesis-intellij/src/main/java/org/labs/genesis/forms/SQLRunnerForm.java
+++ b/genesis-intellij/src/main/java/org/labs/genesis/forms/SQLRunnerForm.java
@@ -63,7 +63,7 @@ public class SQLRunnerForm {
 
     private void addLocationFieldListener() {
         // Crée le FileChooserDescriptor pour sélectionner un seul fichier .sql
-        FileChooserDescriptor fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()
+        FileChooserDescriptor fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
                 .withTitle("Select SQL File")
                 .withDescription("Choose a .sql file to load into the editor")
                 .withFileFilter(file -> {
@@ -212,7 +212,7 @@ public class SQLRunnerForm {
             this.llmApiClient.setDefaultModel(llmApiConfig.getModel());
             this.llmApiClient.setApiUrl(llmApiConfig.getApiUrl());
             if(this.llmApiClient.getUseCustomApiKey()) {
-                this.llmApiClient.setApiKey(this.tokenApiField.getText().trim());
+                this.llmApiClient.setApiKey(new String(this.tokenApiField.getPassword()).trim());
             } else {
                 this.llmApiClient.setApiKeyFromFile();
             }

--- a/genesis-intellij/src/main/java/org/labs/genesis/wizards/FrontendConfigurationWizardStep.java
+++ b/genesis-intellij/src/main/java/org/labs/genesis/wizards/FrontendConfigurationWizardStep.java
@@ -198,7 +198,7 @@ public class FrontendConfigurationWizardStep extends ModuleWizardStep {
             return true;
         }
         catch (Exception e) {
-            throw new ConfigurationException(e.getMessage());
+            throw new ConfigurationException(e.getLocalizedMessage());
         }
     }
     public boolean multivalidate() throws ConfigurationException {
@@ -222,7 +222,7 @@ public class FrontendConfigurationWizardStep extends ModuleWizardStep {
             return true;
         }
         catch (Exception e) {
-            throw new ConfigurationException(e.getMessage());
+            throw new ConfigurationException(e.getLocalizedMessage());
         }
     }
 

--- a/genesis-intellij/src/main/java/org/labs/genesis/wizards/SyncProjectLoaderWizardStep.java
+++ b/genesis-intellij/src/main/java/org/labs/genesis/wizards/SyncProjectLoaderWizardStep.java
@@ -49,7 +49,7 @@ public class SyncProjectLoaderWizardStep extends ModuleWizardStep {
                 throw new ConfigurationException("Genesis context file not found. Please select a valid project directory");
             }
         } catch (Exception e) {
-            throw new ConfigurationException(e.getMessage());
+            throw new ConfigurationException(e.getLocalizedMessage());
         }
         return true;
     }


### PR DESCRIPTION
- Remplacer JPasswordField.getText() par getPassword() dans SQLRunnerForm

- Supprimer la surcharge dépréciée AbstractWizard.getHelpID() dans GenesisWizardDialog

- Remplacer FileChooserDescriptorFactory.createSingleFileDescriptor() par createSingleFileNoJarsDescriptor()

- Utiliser getLocalizedMessage() lors de la gestion des ConfigurationException